### PR TITLE
Replace problems link

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <a href="./countries/.">Countries</a> &bull;
     <a href="./search/.">Search</a> &bull;
     <a href="./hall-of-fame/.">Hall of Fame</a> &bull;
-    <a target="_blank" href="http://ipho.olimpicos.net/">Problems</a> &bull;
+    <a target="_blank" href="http://phoxiv.org/">Problems</a> &bull;
     <a target="_blank" href="https://en.wikipedia.org/wiki/International_Physics_Olympiad">About IPhO</a> &bull;
     <a target="_blank" href="https://ipho-new.org/">Official IPhO Website</a>
   </div>


### PR DESCRIPTION
https://ipho.olimpicos.net/ does not have the experimental solutions to IPhO 2025. Replaced it with https://phoxiv.org/, which has all the relevant files.